### PR TITLE
Add slash commands to bot

### DIFF
--- a/discmoji/command.py
+++ b/discmoji/command.py
@@ -16,10 +16,10 @@ class Command:
         if not function:
             try:
                 return self.callback()
-            except:
+            except Exception as e:
                 tasks = []
                 for handler in self.__error_handlers:
-                    tasks.append(handler())
+                    tasks.append(handler(e))
                 asyncio.run(gather(*tasks))
         self.callback : Callable = function
         if not self.name: self.name : str = function.__name__
@@ -41,10 +41,10 @@ class SlashCommand:
         if not function:
             try:
                 return self.callback()
-            except:
+            except Exception as e:
                 tasks = []
                 for handler in self.__error_handlers:
-                    tasks.append(handler())
+                    tasks.append(handler(e))
                 asyncio.run(gather(*tasks))
         self.callback: Callable = function
         if not self.name:

--- a/discmoji/command.py
+++ b/discmoji/command.py
@@ -28,3 +28,29 @@ class Command:
 
     def error(self, function: Callable) -> None:
         self.__error_handlers += function
+
+
+class SlashCommand:
+    """Represents a slash command."""
+    def __init__(self, name: str):
+        self.name = name
+        self.callback: Optional[Callable] = None
+        self.__error_handlers: List[Callable] = []
+
+    def __call__(self, function: Callable | None = None) -> None:
+        if not function:
+            try:
+                return self.callback()
+            except:
+                tasks = []
+                for handler in self.__error_handlers:
+                    tasks.append(handler())
+                asyncio.run(gather(*tasks))
+        self.callback: Callable = function
+        if not self.name:
+            self.name: str = function.__name__
+        self.bot._all_slash_cmds += self
+        return self
+
+    def error(self, function: Callable) -> None:
+        self.__error_handlers += function

--- a/discmoji/context.py
+++ b/discmoji/context.py
@@ -88,10 +88,71 @@ class Invoked:
             tobepayloaded = json.loads(recved)
             return Message(Payload(None,tobepayloaded,None,None).data)
     
+    async def send_slash_message(self, text: Optional[str], embeds: Embed | List[Embed] | None) -> Message:
+        embed: Embed | None = None
+        if embeds is not None:
+            if len(embeds) == 1:
+                embed = embeds._dictize()
+                if text is None:
+                    msg = await self._endpoint.httpclient.post(f'/interactions/{self.__msgid}/callback', data={
+                        "type": 4,
+                        "data": {
+                            "embeds": [embed]
+                        }
+                    })
+                    read = await msg.read()
+                    decode = read.decode()
+                    returned = json.loads(decode)
+                    return Message(Payload(None, returned, None, None).data)
+                else:
+                    msg = await self._endpoint.httpclient.post(f'/interactions/{self.__msgid}/callback', data={
+                        "type": 4,
+                        "data": {
+                            "content": text,
+                            "embeds": [embed]
+                        }
+                    })
+                    read = await msg.read()
+                    decode = read.decode()
+                    returned = json.loads(decode)
+                    return Message(Payload(None, returned, None, None).data)
+            if len(embeds) > 1:
+                listembeds: list[Embed] = [_._dictize() for _ in embeds]
+                if text is None:
+                    msg = await self._endpoint.httpclient.post(f'/interactions/{self.__msgid}/callback', data={
+                        "type": 4,
+                        "data": {
+                            "embeds": listembeds
+                        }
+                    })
+                    read = await msg.read()
+                    decode = read.decode()
+                    returned = json.loads(decode)
+                    return Message(Payload(None, returned, None, None).data)
+                else:
+                    msg = await self._endpoint.httpclient.post(f'/interactions/{self.__msgid}/callback', data={
+                        "type": 4,
+                        "data": {
+                            "content": text,
+                            "embeds": listembeds
+                        }
+                    })
+                    read = await msg.read()
+                    decode = read.decode()
+                    returned = json.loads(decode)
+                    return Message(Payload(None, returned, None, None).data)
+        else:
+            msg = await self._endpoint.httpclient.post(f'/interactions/{self.__msgid}/callback', data={
+                "type": 4,
+                "data": {
+                    "content": text
+                }
+            })
+            read = await msg.read()
+            recved = read.decode()
+            tobepayloaded = json.loads(recved)
+            return Message(Payload(None, tobepayloaded, None, None).data)
 
-
-    
-    
     async def invoked_cmd_handler(self):
         asyncio.sleep(5.5)
         # checks every 5.5 seconds for new commands


### PR DESCRIPTION
Add slash command functionality to the bot.

* **discmoji/bot.py**
  - Add a new attribute `_all_slash_cmds` to store all registered slash commands.
  - Add a new method `slash_command` to register slash commands.
  - Add a new method `register_slash_commands` to register all slash commands with Discord.
  - Modify the `connect` method to call `register_slash_commands`.

* **discmoji/command.py**
  - Add a new class `SlashCommand` to represent a slash command.
  - Add a new method `error` to the `SlashCommand` class to handle errors.

* **discmoji/context.py**
  - Add a new method `send_slash_message` to the `Invoked` class to send messages for slash commands.

