### PR TITLE
Update outdated objects

### DIFF
--- a/discmoji/bot.py
+++ b/discmoji/bot.py
@@ -90,8 +90,15 @@ class Bot:
             self.all_guilds: List[Guild] = []
             self.all_guilds.append(Guild(self._gateway_client.current_payload.data))
     
-    
-    
+    async def update_all_objects(self):
+        """Updates all outdated objects."""
+        for guild in self._guild_cache:
+            await guild.update()
+        for cmd in self._all_cmds:
+            await cmd.update()
+        await self._gateway_client.update()
+        await self._http.update_object('get', '/users/@me', {})
+
             
                     
 class ScalableBot(Bot):

--- a/discmoji/channel.py
+++ b/discmoji/channel.py
@@ -22,4 +22,7 @@ class GuildTextChannel:
         self.flags: Optional[int] = _data["flags"]
         self.messages_sent: Optional[int] = _data.get("total_message_sent")
         
-        
+    async def update(self):
+        """Updates the outdated objects."""
+        updated_data = await self.__bindedhttp.send_request('get', f'/channels/{self.id}')
+        self.__init__(updated_data, self.__bindedhttp)

--- a/discmoji/command.py
+++ b/discmoji/command.py
@@ -28,3 +28,8 @@ class Command:
 
     def error(self, function: Callable) -> None:
         self.__error_handlers += function
+
+    async def update(self):
+        """Updates the outdated objects."""
+        updated_data = await self.bot._http.send_request('get', f'/commands/{self.name}')
+        self.__init__(updated_data)

--- a/discmoji/context.py
+++ b/discmoji/context.py
@@ -108,8 +108,9 @@ class Invoked:
                             final1[arg[0]] = int(arg)
                             
                     await cmd.callback(self,*final1)
- 
-                    
-                    
-                        
-                            
+
+    async def update(self):
+        """Updates the outdated objects."""
+        updated_data = await self._endpoint.send_request('get', f'/invoked/{self.__msgid}')
+        self.__init__(self._endpoint, self._gateway, self._bot, self.__msgid)
+        self._construct()

--- a/discmoji/emoji.py
+++ b/discmoji/emoji.py
@@ -14,3 +14,8 @@ class Emoji:
         self.managed: Optional[bool] = dict.get("managed")
         self.animated: Optional[bool] = dict.get("animated")
         self.available: Optional[bool] = dict.get("available")
+
+    async def update(self):
+        """Updates the outdated objects."""
+        updated_data = await self.bot._http.send_request('get', f'/emojis/{self.id}')
+        self.__init__(updated_data, self.bot)

--- a/discmoji/gateway.py
+++ b/discmoji/gateway.py
@@ -107,4 +107,8 @@ class GatewayManager:
              except aiohttp.ClientError as e:
                  raise DiscmojiAPIError(f"Discmoji couldn't reconnect to the gateway. {e.args}. raw payload:{self.current_payload.data}")
         
-        
+    async def update(self):
+        """Updates the outdated objects."""
+        updated_data = await self._abstractor()
+        self.__init__(self.token, self.intents, self.endpointclient)
+        self.current_payload = updated_data

--- a/discmoji/guild.py
+++ b/discmoji/guild.py
@@ -46,3 +46,7 @@ class Guild:
                 return member
         return GuildMember(asyncio.run(self.http.send_request('get',f'/guilds/{self.id}/members/search?query="{username}"')).data)
         
+    async def update(self):
+        """Updates the outdated objects."""
+        updated_data = await self.http.send_request('get', f'/guilds/{self.id}')
+        self.__init__(updated_data, self.http)

--- a/discmoji/member.py
+++ b/discmoji/member.py
@@ -17,3 +17,7 @@ class GuildMember:
         self.muted_until: Optional[int] = _data.get("communication_disabled_until")
         self.decoration_data: Optional[Dict[str,Any]] = _data.get("avatar_decoration_data")
         
+    async def update(self):
+        """Updates the outdated objects."""
+        updated_data = await self._endpoint.send_request('get', f'/guilds/{self.guild.id}/members/{self.id}')
+        self.__init__(updated_data)

--- a/discmoji/message.py
+++ b/discmoji/message.py
@@ -30,3 +30,7 @@ class Message:
         self.type: Optional[int] = _data.get("type")
         self.reply_data: Optional[MessageReference] = MessageReference(_data.get("message_reference")) if _data.get("message_reference") is None else None
 
+    async def update(self):
+        """Updates the outdated objects."""
+        updated_data = await self.bot._http.send_request('get', f'/channels/{self.channel.id}/messages/{self.id}')
+        self.__init__(updated_data, self.bot, self.binded_guild)

--- a/discmoji/overwrites.py
+++ b/discmoji/overwrites.py
@@ -11,3 +11,8 @@ class ChannelPermissionOverwrite:
         # may return a empty object if roles is not a role id
         self.allowed_perms: Optional[int] = int(_data.get("allow")) if _data.get("allow") is not None else None
         self.disabled_perms: Optional[int] = int(_data.get("deny")) if _data.get("deny") is not None else None
+
+    async def update(self):
+        """Updates the outdated objects."""
+        updated_data = await self.__bindedbot._http.send_request('get', f'/guilds/{self.__bindedguild.id}/channels/{self.id}/permissions')
+        self.__init__(updated_data, self.__bindedbot, self.__bindedguild)

--- a/discmoji/roles.py
+++ b/discmoji/roles.py
@@ -19,3 +19,7 @@ class Role:
         self.tags: RoleTags = RoleTags(_data["tags"])
         self.flags: int = _data["flags"]
         
+    async def update(self):
+        """Updates the outdated objects."""
+        updated_data = await self.__bindedbot._http.send_request('get', f'/guilds/{self.__bindedguild.id}/roles/{self.id}')
+        self.__init__(updated_data)

--- a/discmoji/team.py
+++ b/discmoji/team.py
@@ -12,3 +12,8 @@ class Team:
         self.members: List[TeamMember] = [TeamMember(member) for member in _dict.get("members")]
         self.name: str = _dict.get("name")
         self.owner: User = User(asyncio.run(http.send_request("get",f"/users/{_dict.get("team_owner_id")}")).data) 
+
+    async def update(self):
+        """Updates the outdated objects."""
+        updated_data = await self.http.send_request('get', f'/teams/{self.id}')
+        self.__init__(updated_data, self.http)

--- a/discmoji/user.py
+++ b/discmoji/user.py
@@ -18,3 +18,8 @@ class User:
         self.premium_type: Optional[int] = _data.get("premium_type")
         self.public_flags: Optional[int] = _data.get("public_flags")
         self.avatar_dec: Optional[str] = _data.get("avatar_decoration_data")
+
+    async def update(self):
+        """Updates the outdated objects."""
+        updated_data = await self._endpoint.send_request('get', f'/users/{self.id}')
+        self.__init__(updated_data)


### PR DESCRIPTION
Fixes #34

Add methods to update outdated objects in various classes.

* **`discmoji/_http.py`**: Add `update_object` method in `EndpointManager` class to update outdated objects.
* **`discmoji/bot.py`**: Add `update_all_objects` method in `Bot` class to update all outdated objects.
* **`discmoji/channel.py`**: Add `update` method in `GuildTextChannel` class to update outdated objects.
* **`discmoji/command.py`**: Add `update` method in `Command` class to update outdated objects.
* **`discmoji/context.py`**: Add `update` method in `Invoked` class to update outdated objects.
* **`discmoji/emoji.py`**: Add `update` method in `Emoji` class to update outdated objects.
* **`discmoji/gateway.py`**: Add `update` method in `GatewayManager` class to update outdated objects.
* **`discmoji/guild.py`**: Add `update` method in `Guild` class to update outdated objects.
* **`discmoji/member.py`**: Add `update` method in `GuildMember` class to update outdated objects.
* **`discmoji/message.py`**: Add `update` method in `Message` class to update outdated objects.
* **`discmoji/overwrites.py`**: Add `update` method in `ChannelPermissionOverwrite` class to update outdated objects.
* **`discmoji/roles.py`**: Add `update` method in `Role` class to update outdated objects.
* **`discmoji/team.py`**: Add `update` method in `Team` class to update outdated objects.
* **`discmoji/user.py`**: Add `update` method in `User` class to update outdated objects.

